### PR TITLE
feat(homepage): add opening night countdown

### DIFF
--- a/web/components/HomePage/HomepageGamesSection.test.tsx
+++ b/web/components/HomePage/HomepageGamesSection.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import HomepageGamesSection from "./HomepageGamesSection";
 
@@ -16,6 +16,10 @@ vi.mock("components/common/OptimizedImage", () => ({
 }));
 
 describe("HomepageGamesSection", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("shows live period and time remaining instead of a scheduled start time", () => {
     render(
       <HomepageGamesSection
@@ -50,5 +54,34 @@ describe("HomepageGamesSection", () => {
         .getAllByRole("link", { name: /game grid/i })
         .some((link) => link.getAttribute("href") === "/game-grid/7-Day-Forecast")
     ).toBe(true);
+  });
+
+  it("shows a real-data opening night countdown when the offseason slate is empty", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-15T16:00:00.000Z"));
+
+    render(
+      <HomepageGamesSection
+        currentDate="2026-07-15"
+        games={[]}
+        gamesHeaderText="Today's"
+        onChangeDate={() => {}}
+        loading={false}
+        error={null}
+        lastUpdatedAt="2026-07-15T16:00:00.000Z"
+        openingNightDate="2026-09-29"
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /opening night countdown/i })
+    ).toBeTruthy();
+    expect(screen.getByText(/Sep 29, 2026/)).toBeTruthy();
+    expect(screen.queryByText(/No games scheduled for 07\/15\/2026/i)).toBeNull();
+    expect(
+      screen.getByLabelText(/time remaining until nhl opening night/i)
+    ).toBeTruthy();
+    expect(screen.getByText("75")).toBeTruthy();
+    expect(screen.getByText(/puck-drop time updates when the NHL schedule/i)).toBeTruthy();
   });
 });

--- a/web/components/HomePage/HomepageGamesSection.tsx
+++ b/web/components/HomePage/HomepageGamesSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
 
 import Link from "next/link";
 import moment from "moment";
@@ -39,7 +39,16 @@ type HomepageGamesSectionProps = {
     caption: string;
   }>;
   pulsePoints?: HomepagePulsePoint[];
+  openingNightDate?: string | null;
+  openingNightStartTime?: string | null;
 };
+
+const COUNTDOWN_UNITS = [
+  ["days", "Days"],
+  ["hours", "Hours"],
+  ["minutes", "Minutes"],
+  ["seconds", "Seconds"],
+] as const;
 
 export default function HomepageGamesSection({
   currentDate,
@@ -54,6 +63,8 @@ export default function HomepageGamesSection({
   playoffWeekGames = [],
   heroMetrics = [],
   pulsePoints = [],
+  openingNightDate = null,
+  openingNightStartTime = null,
 }: HomepageGamesSectionProps) {
   const liveGames = games.filter(
     (game) => game.gameState === "LIVE" || game.gameState === "CRIT",
@@ -71,6 +82,22 @@ export default function HomepageGamesSection({
     (game) => typeof game.startTimeUTC === "string",
   );
   const [scheduleContext, setScheduleContext] = useState<string | null>(null);
+  const [countdownNow, setCountdownNow] = useState<number | null>(null);
+  const hasOfficialPuckDrop = Boolean(
+    openingNightStartTime && moment(openingNightStartTime).isValid(),
+  );
+  const openingNightTarget = useMemo(() => {
+    const date = openingNightDate?.slice(0, 10);
+    if (!date) return null;
+
+    const scheduledStart = openingNightStartTime
+      ? moment(openingNightStartTime).tz("America/New_York")
+      : null;
+    const target = scheduledStart?.isValid()
+      ? scheduledStart
+      : moment.tz(date, "YYYY-MM-DD", "America/New_York").startOf("day");
+    return target.isValid() ? target : null;
+  }, [openingNightDate, openingNightStartTime]);
 
   useEffect(() => {
     if (!firstScheduledGame?.startTimeUTC) {
@@ -80,6 +107,36 @@ export default function HomepageGamesSection({
 
     setScheduleContext(formatLocalStartTime(firstScheduledGame.startTimeUTC));
   }, [firstScheduledGame?.startTimeUTC]);
+
+  useEffect(() => {
+    if (!openingNightTarget) {
+      setCountdownNow(null);
+      return;
+    }
+
+    const updateCountdown = () => setCountdownNow(Date.now());
+    updateCountdown();
+    const interval = window.setInterval(updateCountdown, 1_000);
+    return () => window.clearInterval(interval);
+  }, [openingNightTarget]);
+
+  const openingNightCountdown = useMemo(() => {
+    if (!openingNightTarget || countdownNow === null) return null;
+    const remaining = Math.max(openingNightTarget.valueOf() - countdownNow, 0);
+
+    return {
+      days: Math.floor(remaining / 86_400_000),
+      hours: Math.floor((remaining % 86_400_000) / 3_600_000),
+      minutes: Math.floor((remaining % 3_600_000) / 60_000),
+      seconds: Math.floor((remaining % 60_000) / 1_000),
+      complete: remaining === 0,
+    };
+  }, [countdownNow, openingNightTarget]);
+  const showOpeningNightCountdown = Boolean(
+    games.length === 0 &&
+      openingNightTarget &&
+      (!openingNightCountdown || !openingNightCountdown.complete),
+  );
 
   const heroDescription = playoffsActive
     ? liveGames > 0
@@ -151,13 +208,59 @@ export default function HomepageGamesSection({
         </div>
 
         <div className={styles.gamesContainer}>
-          {modulePresentation.panelState && (
+          {modulePresentation.panelState &&
+          !(
+            showOpeningNightCountdown &&
+            modulePresentation.panelState === "empty"
+          ) ? (
             <PanelStatus
               state={modulePresentation.panelState}
               message={modulePresentation.message ?? ""}
               className={styles.moduleStatusPanel}
             />
-          )}
+          ) : null}
+          {showOpeningNightCountdown ? (
+            <section
+              className={styles.openingNightCountdown}
+              aria-labelledby="opening-night-countdown-heading"
+            >
+              <div className={styles.openingNightIntro}>
+                <span>Next season</span>
+                <h3 id="opening-night-countdown-heading">
+                  Opening night countdown
+                </h3>
+                <p>
+                  The slate returns on{" "}
+                  <time dateTime={openingNightTarget?.toISOString()}>
+                    {hasOfficialPuckDrop
+                      ? openingNightTarget?.format("MMM D, YYYY · h:mm A z")
+                      : openingNightTarget?.format("MMM D, YYYY")}
+                  </time>
+                  .
+                </p>
+                <small>
+                  {hasOfficialPuckDrop
+                    ? "Puck-drop time from the official NHL schedule."
+                    : "Official season date from the FHFH registry; puck-drop time updates when the NHL schedule is available."}
+                </small>
+              </div>
+              <div
+                className={styles.countdownGrid}
+                aria-label="Time remaining until NHL opening night"
+              >
+                {COUNTDOWN_UNITS.map(([key, label]) => (
+                  <span className={styles.countdownUnit} key={key}>
+                    <strong>
+                      {openingNightCountdown
+                        ? String(openingNightCountdown[key]).padStart(2, "0")
+                        : "--"}
+                    </strong>
+                    <small>{label}</small>
+                  </span>
+                ))}
+              </div>
+            </section>
+          ) : null}
           {playoffsActive && playoffBracket ? (
             <HomepagePlayoffBracket
               currentDate={currentDate}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -122,6 +122,8 @@ const Home: NextPage = ({
   recentInjuryNews,
   homepagePlayerCount,
   homepagePulsePoints,
+  openingNightDate,
+  openingNightStartTime,
   draftRankerHomepageEnabled,
 }) => {
   const {
@@ -202,6 +204,8 @@ const Home: NextPage = ({
             },
           ]}
           pulsePoints={homepagePulsePoints}
+          openingNightDate={openingNightDate}
+          openingNightStartTime={openingNightStartTime}
         />
         <ClientOnly>
           {draftRankerHomepageEnabled ? (
@@ -476,6 +480,30 @@ export async function getServerSideProps({ req, res }) {
   let gamesToday = [];
   let playoffWeekGames = [];
   let nextGameDateFound = today;
+  let openingNightDate = null;
+  let openingNightStartTime = null;
+
+  try {
+    const { data, error } = await supabaseServer
+      .from("seasons")
+      .select("startDate")
+      .gte("startDate", today)
+      .order("startDate", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    if (error) throw error;
+    openingNightDate = data?.startDate ?? null;
+
+    if (openingNightDate) {
+      const openingNightGames = await fetchGames(openingNightDate);
+      openingNightStartTime = openingNightGames.games
+        .map((game: any) => game?.startTimeUTC)
+        .filter((value: unknown): value is string => typeof value === "string")
+        .sort()[0] ?? null;
+    }
+  } catch (error: any) {
+    console.error("Error fetching the next NHL opening night:", error.message);
+  }
 
   if (isOffseason) {
     console.log("Currently in offseason - skipping game search");
@@ -624,6 +652,8 @@ export async function getServerSideProps({ req, res }) {
       recentInjuryNews,
       homepagePlayerCount,
       homepagePulsePoints,
+      openingNightDate,
+      openingNightStartTime,
       draftRankerHomepageEnabled:
         isDraftRankerEnabled() && isDraftRankerHomepageEnabled(),
     },

--- a/web/styles/Home.module.scss
+++ b/web/styles/Home.module.scss
@@ -179,6 +179,97 @@
   background: v.$background-dark;
 }
 
+.openingNightCountdown {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) minmax(360px, auto);
+  align-items: center;
+  gap: v.$space-lg;
+  min-height: 112px;
+  padding: v.$space-md v.$space-lg;
+  border: 1px solid rgba(v.$primary-color, 0.34);
+  border-radius: v.$radius-card;
+  background:
+    linear-gradient(100deg, rgba(v.$primary-color, 0.14), transparent 46%),
+    radial-gradient(circle at 88% 20%, rgba(v.$primary-color, 0.12), transparent 34%),
+    v.$background-medium;
+}
+
+.openingNightIntro {
+  display: grid;
+  gap: 4px;
+
+  > span,
+  small {
+    color: v.$primary-color;
+    font-size: 0.68rem;
+    font-weight: v.$font-weight-semibold;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  h3,
+  p {
+    margin: 0;
+  }
+
+  h3 {
+    color: v.$color-white;
+    font-family: v.$font-family-accent, v.$font-family-primary, sans-serif;
+    font-size: clamp(1.15rem, 2vw, 1.55rem);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  p {
+    color: v.$text-primary;
+    font-size: v.$font-size-sm;
+  }
+
+  time {
+    color: v.$color-white;
+    font-family: v.$font-family-numbers;
+    font-weight: v.$font-weight-semibold;
+  }
+
+  small {
+    color: v.$text-secondary;
+    letter-spacing: 0.04em;
+    text-transform: none;
+  }
+}
+
+.countdownGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(64px, 1fr));
+  gap: v.$space-xs;
+}
+
+.countdownUnit {
+  display: grid;
+  justify-items: center;
+  gap: 3px;
+  min-width: 64px;
+  padding: v.$space-sm;
+  border: 1px solid rgba(v.$border-secondary, 0.86);
+  border-radius: v.$radius-control;
+  background: rgba(v.$background-dark, 0.78);
+
+  strong {
+    color: v.$color-white;
+    font-family: v.$font-family-numbers;
+    font-size: clamp(1.25rem, 2.3vw, 1.75rem);
+    font-weight: v.$font-weight-semibold;
+    line-height: 1;
+  }
+
+  small {
+    color: v.$text-secondary;
+    font-size: 0.62rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+}
+
 .gamesGrid {
   display: flex;
   gap: v.$space-sm;
@@ -1168,6 +1259,11 @@
     width: 100%;
   }
 
+  .openingNightCountdown {
+    grid-template-columns: 1fr;
+    gap: v.$space-md;
+  }
+
   .slateSummaryRail {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -1249,6 +1345,14 @@
   .gameLink {
     flex-basis: 142px;
     min-width: 142px;
+  }
+
+  .openingNightCountdown {
+    padding: v.$space-md;
+  }
+
+  .countdownGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .slateHeroIntro {


### PR DESCRIPTION
## Summary
- show an offseason countdown in Today’s Games using the next season start date from Supabase
- use the earliest official NHL schedule timestamp when one is available
- expose the existing account-backed Personal Draft Ranker when the homepage flag is enabled
- keep loading and error states while replacing the duplicate empty-slate message

## Safety boundary
- rollout stage remains staff
- this change does not enable community contribution, discovery, beta, or public aggregate features
- no database migration or dummy data is included

## Verification
- 6 focused component tests passed
- TypeScript check passed
- production Next.js build passed
- production-mode visual verification passed for countdown, ranker card, one News panel left of League Separation, and no application-error UI