### PR TITLE
Fix homepage timestamp hydration

### DIFF
--- a/web/components/HomePage/HomepageStandingsInjuriesSection.test.tsx
+++ b/web/components/HomePage/HomepageStandingsInjuriesSection.test.tsx
@@ -153,7 +153,7 @@ describe("HomepageStandingsInjuriesSection", () => {
               "Mason McTavish and Anaheim are making progress on a contract extension.",
             category: "NEWS UPDATE",
             team_abbreviation: "ANA",
-            published_at: "2026-07-14T12:00:00.000Z",
+            published_at: "2026-07-15T01:00:00.000Z",
             source_url: "https://x.com/OriginalReporter/status/2",
             players: [{ player_name: "Mason McTavish" }],
           },
@@ -165,6 +165,10 @@ describe("HomepageStandingsInjuriesSection", () => {
     );
 
     expect(screen.getByText("Mason McTavish")).toBeTruthy();
+    const transactionTable = screen.getByRole("table", {
+      name: /recent nhl transactions/i,
+    });
+    expect(within(transactionTable).getByText("7/14/26")).toBeTruthy();
     expect(screen.getByText("NEWS UPDATE")).toBeTruthy();
     expect(
       screen.getByText(

--- a/web/components/HomePage/HomepageStandingsInjuriesSection.tsx
+++ b/web/components/HomePage/HomepageStandingsInjuriesSection.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import moment from "moment";
+import moment from "moment-timezone";
 import Link from "next/link";
 
 import ExternalNewsLink from "components/common/ExternalNewsLink";
@@ -26,6 +26,15 @@ type HomepageStandingsInjuriesSectionProps = {
 };
 
 const ROWS_PER_PAGE = 32;
+const HOMEPAGE_TIME_ZONE = "America/New_York";
+
+function formatHomepageDate(value: string | null | undefined): string {
+  if (!value) return "N/A";
+  const parsed = moment(value);
+  return parsed.isValid()
+    ? parsed.tz(HOMEPAGE_TIME_ZONE).format("M/D/YY")
+    : "N/A";
+}
 
 function newsItemToHomepageInjury(item: NewsFeedItem) {
   const playerNames = item.players
@@ -300,9 +309,9 @@ export default function HomepageStandingsInjuriesSection({
                     return (
                       <tr key={transaction.id}>
                         <td className={styles.dateColumn}>
-                          {moment(
+                          {formatHomepageDate(
                             transaction.published_at ?? transaction.created_at,
-                          ).format("M/D/YY")}
+                          )}
                         </td>
                         <td className={styles.teamColumn}>
                           <OptimizedImage
@@ -385,9 +394,7 @@ export default function HomepageStandingsInjuriesSection({
                       className={rowClassName}
                     >
                       <td className={styles.dateColumn}>
-                        {injury.date
-                          ? moment(injury.date).format("M/D/YY")
-                          : "N/A"}
+                        {formatHomepageDate(injury.date)}
                       </td>
                       <td className={styles.teamColumn}>
                         <OptimizedImage

--- a/web/components/NewsFeed/NewsCard.test.tsx
+++ b/web/components/NewsFeed/NewsCard.test.tsx
@@ -51,5 +51,6 @@ describe("NewsCard", () => {
     );
     expect(sourceLink.getAttribute("target")).toBe("_blank");
     expect(screen.queryByText("Source")).toBeNull();
+    expect(screen.getByText("7/14/2026, 2:19:20 PM")).toBeTruthy();
   });
 });

--- a/web/components/NewsFeed/NewsCard.tsx
+++ b/web/components/NewsFeed/NewsCard.tsx
@@ -42,11 +42,21 @@ type NewsCardProps = {
   onLineupGoalieSlotClick?: (slotIndex: number) => void;
 };
 
+const NEWS_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  timeZone: "America/New_York",
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  second: "2-digit",
+});
+
 function formatDate(value: string | null | undefined): string {
   if (!value) return "Draft";
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString();
+  return NEWS_TIMESTAMP_FORMATTER.format(date);
 }
 
 function LineupSlot({


### PR DESCRIPTION
## What changed

- format NewsCard timestamps in the product Eastern timezone on both server and client
- format homepage transaction and injury dates in the same explicit timezone
- add regression coverage for full timestamps and UTC-midnight date rollover

## Why

The live homepage rendered news timestamps in UTC during SSR and Eastern time in the browser. React detected the text mismatch during hydration, emitted errors 418/423/425, and replaced the server-rendered tree.

## Verification

- focused homepage tests: 8/8
- full Draft Ranker suite: 230/230 across 49 files
- `npx tsc --noEmit --pretty false`
- `npm run build`
- `git diff --check`

No database, auth, ranking, feature-flag, or API behavior changes.