### PR TITLE
fix(cron): prevent silent audit skips

### DIFF
--- a/web/lib/cron/withCronJobAudit.test.ts
+++ b/web/lib/cron/withCronJobAudit.test.ts
@@ -243,4 +243,16 @@ describe("withCronJobAudit", () => {
       "audit insert unavailable",
     );
   });
+
+  it("does not silently skip persistence when runtime configuration is unavailable", async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const wrapped = withCronJobAudit(
+      async (_req, res) => res.json({ success: true }),
+      { jobName: "runtime-config-audit" },
+    );
+
+    await wrapped(createMockReq(), createMockRes());
+
+    expect(insertMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/web/lib/cron/withCronJobAudit.ts
+++ b/web/lib/cron/withCronJobAudit.ts
@@ -223,9 +223,6 @@ export function withCronJobAudit(
     };
 
     try {
-      if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
-        return;
-      }
       const { error: auditInsertError } = await supabase
         .from("cron_job_audit")
         .insert(row as any);


### PR DESCRIPTION
## Summary
- remove the redundant environment early-return that can silently suppress cron audit persistence
- rely on the existing service client to validate runtime configuration and surface failures
- add a regression proving persistence is still attempted when direct environment inspection is unavailable

## Production evidence
- July 16 Draft Ranker health cron returned HTTP 200 at 12:45:20 UTC
- counts-only health response is healthy, but no cron_job_audit row was written
- an authenticated manual GET reproduced the same missing audit record

## Verification
- withCronJobAudit: 7/7 tests
- TypeScript: pass
- git diff --check: pass