### PR TITLE
fix(cron): persist audits before sending responses

### DIFF
--- a/web/lib/cron/withCronJobAudit.test.ts
+++ b/web/lib/cron/withCronJobAudit.test.ts
@@ -255,4 +255,30 @@ describe("withCronJobAudit", () => {
 
     expect(insertMock).toHaveBeenCalledTimes(1);
   });
+
+  it("persists the audit before flushing the JSON response", async () => {
+    let resolveInsert: ((value: unknown) => void) | undefined;
+    insertMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveInsert = resolve;
+      }),
+    );
+    const wrapped = withCronJobAudit(
+      async (_req, res) => res.json({ success: true, rowsAffected: 0 }),
+      { jobName: "durable-audit" },
+    );
+    const res = createMockRes();
+
+    const pending = wrapped(createMockReq(), res);
+    await vi.waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
+
+    expect(res.headersSent).toBe(false);
+    expect(res.body).toBeUndefined();
+
+    resolveInsert?.({});
+    await pending;
+
+    expect(res.headersSent).toBe(true);
+    expect(res.body).toEqual({ success: true, rowsAffected: 0 });
+  });
 });

--- a/web/lib/cron/withCronJobAudit.ts
+++ b/web/lib/cron/withCronJobAudit.ts
@@ -154,11 +154,15 @@ export function withCronJobAudit(
     const jobName = opts?.jobName ?? defaultJobName(req);
 
     let capturedBody: unknown = null;
+    let pendingResponse:
+      | { kind: "json" | "send"; body: unknown }
+      | null = null;
 
     const originalJson = res.json.bind(res);
     res.json = ((body: any) => {
       capturedBody = body;
-      return originalJson(body);
+      pendingResponse = { kind: "json", body };
+      return res;
     }) as any;
 
     const originalSend =
@@ -166,7 +170,8 @@ export function withCronJobAudit(
     if (originalSend) {
       res.send = ((body: any) => {
         if (capturedBody == null) capturedBody = body;
-        return originalSend(body);
+        pendingResponse = { kind: "send", body };
+        return res;
       }) as any;
     }
 
@@ -223,19 +228,37 @@ export function withCronJobAudit(
     };
 
     try {
-      const { error: auditInsertError } = await supabase
-        .from("cron_job_audit")
-        .insert(row as any);
-      if (auditInsertError) {
+      try {
+        const { error: auditInsertError } = await supabase
+          .from("cron_job_audit")
+          .insert(row as any);
+        if (auditInsertError) {
+          console.error(
+            "cron_job_audit insert failed",
+            auditInsertError.message ??
+              safeJson(auditInsertError, 2000) ??
+              "Unknown audit insert error",
+          );
+        }
+      } catch (e) {
         console.error(
           "cron_job_audit insert failed",
-          auditInsertError.message ??
-            safeJson(auditInsertError, 2000) ??
-            "Unknown audit insert error",
+          (e as any)?.message ?? e,
         );
       }
-    } catch (e) {
-      console.error("cron_job_audit insert failed", (e as any)?.message ?? e);
+    } finally {
+      const responseToFlush = pendingResponse as
+        | { kind: "json" | "send"; body: unknown }
+        | null;
+      res.json = originalJson as any;
+      if (originalSend) {
+        res.send = originalSend as any;
+      }
+      if (responseToFlush?.kind === "json") {
+        originalJson(responseToFlush.body);
+      } else if (responseToFlush?.kind === "send" && originalSend) {
+        originalSend(responseToFlush.body);
+      }
     }
   };
 }


### PR DESCRIPTION
## Summary
- defer JSON/send response flushing until the cron audit insert resolves
- always restore the original response methods and flush even when persistence reports an error
- add a regression proving the audit resolves before headers are sent

## Production evidence
A 2026-07-16 14:24 UTC Draft Ranker health request returned HTTP 200 on the promoted audit-fix artifact, but no audit row was persisted and no audit error was logged. The wrapper still emitted the response before awaiting storage, allowing the serverless runtime to end first.

## Verification
- 19/19 affected cron and Draft Ranker health tests
- full TypeScript check
- `git diff --check`

No ranking data, migration, or rollout flag change.