### PR TITLE
Cut over Yahoo NHL ingestion to the 2026–27 season

### DIFF
--- a/web/hooks/useProcessedProjectionsData.tsx
+++ b/web/hooks/useProcessedProjectionsData.tsx
@@ -59,11 +59,6 @@ import {
 } from "lib/draftDashboard/projectionSourceSettling";
 export type { CustomAdditionalProjectionSource } from "lib/draftDashboard/customProjectionSources";
 
-// Central constant: current Yahoo game/season prefix for filtering ADP rows.
-// Ensure all yahoo_players and mapping data are restricted to this prefix to avoid prior season leakage.
-export const CURRENT_YAHOO_GAME_ID = 465;
-export const CURRENT_YAHOO_GAME_PREFIX = `${CURRENT_YAHOO_GAME_ID}.`; // (Prev season prefix: 453.)
-
 // --- Types ---
 interface RawPlayerStatFromSource {
   value: number | null;
@@ -703,6 +698,10 @@ async function fetchAllSourceData(
 
   let yahooPlayersMap = new Map<string, YahooPlayerDetailData>();
   if (uniqueYahooPlayerIdsFromMap.size > 0) {
+    const yahooSeason = Number.parseInt(currentSeasonId.slice(0, 4), 10);
+    if (!Number.isFinite(yahooSeason)) {
+      throw new Error("Current season cannot be mapped to a Yahoo season.");
+    }
     const yahooPlayersSelectString = `${YAHOO_PLAYERS_TABLE_KEYS.primaryKey}, ${YAHOO_PLAYERS_TABLE_KEYS.yahooSpecificPlayerId}, ${YAHOO_PLAYERS_TABLE_KEYS.fullName}, ${YAHOO_PLAYERS_TABLE_KEYS.draftAnalysis}, ${YAHOO_PLAYERS_TABLE_KEYS.editorialTeamAbbreviation}, ${YAHOO_PLAYERS_TABLE_KEYS.displayPosition}, ${YAHOO_PLAYERS_TABLE_KEYS.eligiblePositions}, average_draft_pick, average_draft_round, percent_drafted, game_id, season`;
 
     // Split IDs into composite (player_key-like) and bare numeric IDs
@@ -728,7 +727,7 @@ async function fetchAllSourceData(
         supabaseClient
           .from("yahoo_players_with_normalized_history")
           .select(yahooPlayersSelectString)
-          .eq("game_id", CURRENT_YAHOO_GAME_ID)
+          .eq("season", yahooSeason)
           .in(YAHOO_PLAYERS_TABLE_KEYS.primaryKey, playerIdChunk)
           .order(YAHOO_PLAYERS_TABLE_KEYS.primaryKey, { ascending: true })
           .range(from, to),
@@ -744,7 +743,7 @@ async function fetchAllSourceData(
         supabaseClient
           .from("yahoo_players_with_normalized_history")
           .select(yahooPlayersSelectString)
-          .eq("game_id", CURRENT_YAHOO_GAME_ID)
+          .eq("season", yahooSeason)
           .in(YAHOO_PLAYERS_TABLE_KEYS.yahooSpecificPlayerId, playerIdChunk)
           .order(YAHOO_PLAYERS_TABLE_KEYS.primaryKey, { ascending: true })
           .range(from, to),
@@ -757,16 +756,7 @@ async function fetchAllSourceData(
     for (const row of results) {
       const pk: any = (row as any)[YAHOO_PLAYERS_TABLE_KEYS.primaryKey];
       if (!pk) continue;
-      // Prefer rows whose player_key starts with CURRENT_YAHOO_GAME_PREFIX
-      const existing = dedup.get(pk);
-      if (!existing) dedup.set(pk, row);
-      else {
-        const existingPref = (existing as any)[
-          YAHOO_PLAYERS_TABLE_KEYS.primaryKey
-        ]?.startsWith(CURRENT_YAHOO_GAME_PREFIX);
-        const candidatePref = String(pk).startsWith(CURRENT_YAHOO_GAME_PREFIX);
-        if (!existingPref && candidatePref) dedup.set(pk, row);
-      }
+      if (!dedup.has(pk)) dedup.set(pk, row);
     }
 
     // Build map keyed by both player_id and player_key for flexible lookup

--- a/web/lib/integrations/yahoo/discovery.test.ts
+++ b/web/lib/integrations/yahoo/discovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   flattenYahooTeams,
@@ -8,7 +8,9 @@ import {
 } from "./discovery";
 import {
   extractYahooPlayerKeyPage,
+  extractYahooPlayerBatch,
   fetchCompleteYahooPlayerKeySnapshot,
+  fetchYahooPublicJson,
   getYahooRetryAfterMs,
   isYahooGameWeekSnapshotReceipt,
   isYahooSheetExportEligible,
@@ -144,6 +146,36 @@ describe("Yahoo discovery helpers", () => {
         { week: 1, start_date: "2026-10-06", end_date: "2026-10-12" },
         { week: 2, start_date: "2026-10-13", end_date: "2026-10-19" },
       ],
+    });
+  });
+
+  it("normalizes Yahoo's public json_f game-week envelope", () => {
+    expect(
+      prepareYahooGameWeekSnapshot({
+        fantasy_content: {
+          game: {
+            game_key: "477",
+            game_id: "477",
+            name: "Hockey",
+            code: "nhl",
+            type: "full",
+            url: "https://hockey.fantasysports.yahoo.com/hockey",
+            season: "2026",
+            game_weeks: [
+              {
+                game_week: {
+                  week: "1",
+                  start: "2026-09-29",
+                  end: "2026-10-04",
+                },
+              },
+            ],
+          },
+        },
+      }),
+    ).toMatchObject({
+      game: { game_id: 477, game_key: "477", season: 2026 },
+      weeks: [{ week: 1, start_date: "2026-09-29", end_date: "2026-10-04" }],
     });
   });
 
@@ -371,6 +403,73 @@ describe("Yahoo discovery helpers", () => {
       expect.stringContaining("/players;start=0;count=2"),
       expect.stringContaining("/players;start=2;count=2"),
     ]);
+  });
+
+  it("extracts public json_f player keys and enriched player batches", () => {
+    const players = [
+      {
+        player: {
+          player_key: "477.p.6743",
+          player_id: "6743",
+          name: { full: "Connor McDavid" },
+          percent_owned: { value: 100 },
+        },
+      },
+    ];
+
+    expect(
+      extractYahooPlayerKeyPage({
+        fantasy_content: { game: { players } },
+      }),
+    ).toEqual([
+      {
+        player_key: "477.p.6743",
+        player_id: 6743,
+        player_name: "Connor McDavid",
+      },
+    ]);
+    expect(
+      extractYahooPlayerBatch({
+        fantasy_content: { players },
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        player_key: "477.p.6743",
+        percent_owned: { value: 100 },
+      }),
+    ]);
+  });
+
+  it("requests Yahoo's public json_f endpoint and exposes retryable status", async () => {
+    const requestedUrls: string[] = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestedUrls.push(String(input));
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => ({ fantasy_content: { game: {} } }),
+      } as Response;
+    });
+
+    await expect(
+      fetchYahooPublicJson("game/nhl/game_weeks", fetchImpl as typeof fetch),
+    ).resolves.toEqual({ fantasy_content: { game: {} } });
+    expect(requestedUrls[0]).toContain(
+      "pub-api-ro.fantasysports.yahoo.com/fantasy/v2/game/nhl/game_weeks?format=json_f",
+    );
+
+    const unavailable = () =>
+      fetchYahooPublicJson(
+        "game/nhl/game_weeks",
+        (async () =>
+          ({
+            ok: false,
+            status: 503,
+            headers: new Headers(),
+          }) as Response) as typeof fetch,
+      );
+    await expect(unavailable()).rejects.toMatchObject({ status: 503 });
   });
 
   it("fails closed on malformed, repeated, or non-terminating key pages", async () => {

--- a/web/lib/integrations/yahoo/globalCredentials.test.ts
+++ b/web/lib/integrations/yahoo/globalCredentials.test.ts
@@ -124,19 +124,22 @@ describe("Yahoo global credential owner", () => {
     await expect(failed).rejects.not.toThrow(/sensitive-fragment/);
   });
 
-  it("keeps every active global route on the shared owner", () => {
-    const routes = [
-      "manual-refresh-yahoo-token.ts",
-      "update-yahoo-players.ts",
-      "update-yahoo-weeks.ts",
-    ];
+  it("keeps OAuth ownership centralized and public readers token-free", () => {
+    const refreshSource = fs.readFileSync(
+      path.join(process.cwd(), "pages/api/v1/db/manual-refresh-yahoo-token.ts"),
+      "utf8",
+    );
+    expect(refreshSource).toContain(
+      'from "lib/integrations/yahoo/globalCredentials"',
+    );
 
-    for (const route of routes) {
+    for (const route of ["update-yahoo-players.ts", "update-yahoo-weeks.ts"]) {
       const source = fs.readFileSync(
         path.join(process.cwd(), "pages/api/v1/db", route),
         "utf8",
       );
-      expect(source).toContain(
+      expect(source).toContain("fetchYahooPublicJson");
+      expect(source).not.toContain(
         'from "lib/integrations/yahoo/globalCredentials"',
       );
       expect(source).not.toContain('.from("yahoo_api_credentials")');
@@ -152,7 +155,10 @@ describe("Yahoo global credential owner", () => {
       "utf8",
     );
 
-    expect(source).toContain("selectCanonicalYahooGame");
+    expect(source).toContain(
+      'const requestedGameKey = overrideGameId || "nhl"',
+    );
+    expect(source).toContain("prepareYahooGameWeekSnapshot");
     expect(source).toContain("fetchAllSupabasePages");
     expect(source).toContain('.order("player_key", { ascending: true })');
     expect(source).toContain("withYahooRetry");

--- a/web/lib/integrations/yahoo/ingestionLifecycle.ts
+++ b/web/lib/integrations/yahoo/ingestionLifecycle.ts
@@ -7,6 +7,9 @@ type YahooGameRow = {
   current_week?: string | number | null;
 };
 
+const YAHOO_PUBLIC_API_ORIGIN = "https://pub-api-ro.fantasysports.yahoo.com";
+const YAHOO_PUBLIC_API_BASE_URL = `${YAHOO_PUBLIC_API_ORIGIN}/fantasy/v2/`;
+
 type YahooRetryOptions = {
   maxAttempts?: number;
   baseDelayMs?: number;
@@ -102,6 +105,38 @@ function exactIsoDate(value: unknown): string | null {
     : null;
 }
 
+export async function fetchYahooPublicJson(
+  pathOrUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<unknown> {
+  const url = new URL(pathOrUrl, YAHOO_PUBLIC_API_BASE_URL);
+  if (
+    url.origin !== YAHOO_PUBLIC_API_ORIGIN ||
+    !url.pathname.startsWith("/fantasy/v2/")
+  ) {
+    throw new Error("Yahoo public API URL is invalid.");
+  }
+  url.searchParams.set("format", "json_f");
+
+  const response = await fetchImpl(url.toString(), {
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    const error = new Error("Yahoo public API request failed.") as Error & {
+      response?: { headers: Headers; status: number };
+      status?: number;
+    };
+    error.status = response.status;
+    error.response = {
+      headers: response.headers,
+      status: response.status,
+    };
+    throw error;
+  }
+
+  return response.json();
+}
+
 export function prepareYahooGameWeekSnapshot(
   response: unknown,
 ): YahooGameWeekSnapshot {
@@ -109,9 +144,26 @@ export function prepareYahooGameWeekSnapshot(
     throw new Error("Yahoo game-week response is malformed.");
   }
 
-  const gameId = finiteNumber(response.game_id);
-  const season = finiteNumber(response.season);
-  const gameKey = nullableTrimmedText(response.game_key);
+  const fantasyContent = isRecord(response.fantasy_content)
+    ? response.fantasy_content
+    : null;
+  const game =
+    fantasyContent && isRecord(fantasyContent.game)
+      ? fantasyContent.game
+      : response;
+  const rawWeeks = Array.isArray(game.weeks)
+    ? game.weeks
+    : Array.isArray(game.game_weeks)
+      ? game.game_weeks.map((entry) =>
+          isRecord(entry) && entry.game_week !== undefined
+            ? entry.game_week
+            : entry,
+        )
+      : null;
+
+  const gameId = finiteNumber(game.game_id);
+  const season = finiteNumber(game.season);
+  const gameKey = nullableTrimmedText(game.game_key);
   if (
     gameId == null ||
     gameId <= 0 ||
@@ -119,14 +171,14 @@ export function prepareYahooGameWeekSnapshot(
     season < 1900 ||
     !gameKey ||
     !/^[A-Za-z0-9._-]+$/.test(gameKey) ||
-    !Array.isArray(response.weeks) ||
-    response.weeks.length === 0
+    !rawWeeks ||
+    rawWeeks.length === 0
   ) {
     throw new Error("Yahoo game-week response is incomplete.");
   }
 
   const seenWeeks = new Set<number>();
-  const weeks = response.weeks
+  const weeks = rawWeeks
     .map((rawWeek) => {
       if (!isRecord(rawWeek)) {
         throw new Error("Yahoo game-week row is malformed.");
@@ -154,10 +206,10 @@ export function prepareYahooGameWeekSnapshot(
     game: {
       game_id: Math.trunc(gameId),
       game_key: gameKey,
-      name: nullableTrimmedText(response.name),
-      code: nullableTrimmedText(response.code),
-      type: nullableTrimmedText(response.type),
-      url: nullableTrimmedText(response.url),
+      name: nullableTrimmedText(game.name),
+      code: nullableTrimmedText(game.code),
+      type: nullableTrimmedText(game.type),
+      url: nullableTrimmedText(game.url),
       season: Math.trunc(season),
     },
     weeks,
@@ -216,40 +268,94 @@ export function extractYahooPlayerKeyPage(
     ? response.fantasy_content.game
     : [response.fantasy_content.game];
   const holder = gameParts.find(
-    (part) => isRecord(part) && isRecord(part.players),
+    (part) =>
+      isRecord(part) && (isRecord(part.players) || Array.isArray(part.players)),
   );
-  if (!isRecord(holder) || !isRecord(holder.players)) {
+  if (
+    !isRecord(holder) ||
+    (!isRecord(holder.players) && !Array.isArray(holder.players))
+  ) {
     throw new Error("Yahoo player-key collection is missing.");
   }
 
-  const rows = Object.entries(holder.players)
-    .filter(([key]) => /^\d+$/.test(key))
-    .map(([, entry]) => {
-      const playerKey = findNestedValue(entry, "player_key");
-      if (typeof playerKey !== "string" || !/^\d+\.p\.\d+$/.test(playerKey)) {
-        throw new Error("Yahoo player-key row is malformed.");
-      }
+  const entries = Array.isArray(holder.players)
+    ? holder.players
+    : Object.entries(holder.players)
+        .filter(([key]) => /^\d+$/.test(key))
+        .map(([, entry]) => entry);
+  const rows = entries.map((entry) => {
+    const playerKey = findNestedValue(entry, "player_key");
+    if (typeof playerKey !== "string" || !/^\d+\.p\.\d+$/.test(playerKey)) {
+      throw new Error("Yahoo player-key row is malformed.");
+    }
 
-      const rawPlayerId = findNestedValue(entry, "player_id");
-      const playerId = finiteNumber(rawPlayerId);
-      const rawName = findNestedValue(entry, "name");
-      const playerName =
-        isRecord(rawName) && typeof rawName.full === "string"
-          ? rawName.full.trim() || null
-          : null;
+    const rawPlayerId = findNestedValue(entry, "player_id");
+    const playerId = finiteNumber(rawPlayerId);
+    const rawName = findNestedValue(entry, "name");
+    const playerName =
+      isRecord(rawName) && typeof rawName.full === "string"
+        ? rawName.full.trim() || null
+        : null;
 
-      return {
-        player_key: playerKey,
-        player_id: playerId == null ? null : Math.trunc(playerId),
-        player_name: playerName,
-      };
-    });
+    return {
+      player_key: playerKey,
+      player_id: playerId == null ? null : Math.trunc(playerId),
+      player_name: playerName,
+    };
+  });
 
   const uniqueKeys = new Set(rows.map((row) => row.player_key));
   if (uniqueKeys.size !== rows.length) {
     throw new Error("Yahoo player-key page contains duplicate keys.");
   }
   return rows;
+}
+
+export function extractYahooPlayerBatch(
+  response: unknown,
+): Array<Record<string, unknown>> {
+  const fantasyContent = isRecord(response) ? response.fantasy_content : null;
+  const contentPlayers = isRecord(fantasyContent)
+    ? fantasyContent.players
+    : null;
+  const gamePlayers =
+    isRecord(fantasyContent) && isRecord(fantasyContent.game)
+      ? fantasyContent.game.players
+      : null;
+  const collection = Array.isArray(response)
+    ? response
+    : Array.isArray(contentPlayers) || isRecord(contentPlayers)
+      ? contentPlayers
+      : Array.isArray(gamePlayers) || isRecord(gamePlayers)
+        ? gamePlayers
+        : null;
+  if (!collection) {
+    throw new Error("Yahoo player batch is malformed.");
+  }
+
+  const entries = Array.isArray(collection)
+    ? collection
+    : Object.entries(collection)
+        .filter(([key]) => /^\d+$/.test(key))
+        .map(([, entry]) => entry);
+  const players = entries.map((entry) => {
+    const player =
+      isRecord(entry) && isRecord(entry.player) ? entry.player : entry;
+    if (
+      !isRecord(player) ||
+      typeof player.player_key !== "string" ||
+      !/^\d+\.p\.\d+$/.test(player.player_key)
+    ) {
+      throw new Error("Yahoo player batch row is malformed.");
+    }
+    return player;
+  });
+
+  const uniqueKeys = new Set(players.map((player) => player.player_key));
+  if (uniqueKeys.size !== players.length) {
+    throw new Error("Yahoo player batch contains duplicate keys.");
+  }
+  return players;
 }
 
 export async function fetchCompleteYahooPlayerKeySnapshot(
@@ -262,8 +368,8 @@ export async function fetchCompleteYahooPlayerKeySnapshot(
   }
 
   const pageSize = Math.min(
-    25,
-    Math.max(1, Math.trunc(options.pageSize ?? 25)),
+    2_000,
+    Math.max(1, Math.trunc(options.pageSize ?? 2_000)),
   );
   const maxPages = Math.max(1, Math.trunc(options.maxPages ?? 200));
   const players: YahooPlayerKeySnapshotRow[] = [];
@@ -272,11 +378,14 @@ export async function fetchCompleteYahooPlayerKeySnapshot(
   for (let page = 0; page < maxPages; page += 1) {
     const start = page * pageSize;
     const url =
-      `https://fantasysports.yahooapis.com/fantasy/v2/game/${gameId}` +
-      `/players;start=${start};count=${pageSize}`;
+      `${YAHOO_PUBLIC_API_BASE_URL}game/${gameId}` +
+      `/players;start=${start};count=${pageSize}?format=json_f`;
     const pageRows = extractYahooPlayerKeyPage(await requestPage(url));
 
     for (const row of pageRows) {
+      if (!row.player_key.startsWith(`${gameId}.p.`)) {
+        throw new Error("Yahoo player-key page contains another game.");
+      }
       if (seen.has(row.player_key)) {
         throw new Error("Yahoo player-key pagination repeated a key.");
       }

--- a/web/pages/api/v1/db/update-yahoo-players.ts
+++ b/web/pages/api/v1/db/update-yahoo-players.ts
@@ -1,23 +1,22 @@
 // /web/pages/api/v1/db/update-yahoo-players.ts
 
 import { withCronJobAudit } from "lib/cron/withCronJobAudit";
-import {
-  loadYahooGlobalCredentials,
-  persistYahooGlobalTokens,
-} from "lib/integrations/yahoo/globalCredentials";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
-import YahooFantasy from "yahoo-fantasy";
 import { format } from "date-fns";
 import { randomUUID } from "node:crypto";
 import adminOnly from "utils/adminOnlyMiddleware";
 import { fetchAllSupabasePages } from "lib/supabase/pagination";
 import {
+  extractYahooPlayerBatch,
   fetchCompleteYahooPlayerKeySnapshot,
+  fetchYahooPublicJson,
+  isYahooGameWeekSnapshotReceipt,
   isYahooSheetExportEligible,
+  prepareYahooGameWeekSnapshot,
   requestYahooSheetExport,
-  selectCanonicalYahooGame,
   withYahooRetry,
+  type YahooGameWeekSnapshotReceipt,
 } from "lib/integrations/yahoo/ingestionLifecycle";
 import { classifyYahooLifecycleError } from "lib/integrations/yahoo/lifecycleHealth";
 import type { Database } from "lib/supabase/database-generated.types";
@@ -62,49 +61,85 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   console.log("Starting update-yahoo-players handler.");
 
-  try {
-    const creds = await loadYahooGlobalCredentials(supabase);
+  let retries = 0;
+  let rateLimitEvents = 0;
 
+  try {
     // Allow explicit override of gameId via query or JSON body for one-off runs
-    // e.g. GET /api/v1/db/update-yahoo-players?gameId=465
-    const overrideGameId =
+    // while the scheduled path follows Yahoo's live NHL alias.
+    const rawOverrideGameId =
       (req.query?.gameId as string) ||
       (req.body && (req.body.gameId as string));
+    const overrideGameId = rawOverrideGameId ? String(rawOverrideGameId) : null;
     if (overrideGameId && !/^\d+$/.test(overrideGameId)) {
       throw new Error("Yahoo game override is invalid.");
     }
 
-    let gameQuery = supabase
+    const requestedGameKey = overrideGameId || "nhl";
+    const gameResponse = await withYahooRetry(
+      () =>
+        fetchYahooPublicJson(
+          `game/${encodeURIComponent(requestedGameKey)}/game_weeks`,
+        ),
+      {
+        maxAttempts: 3,
+        onRetry: ({ rateLimited }) => {
+          retries += 1;
+          if (rateLimited) rateLimitEvents += 1;
+        },
+      },
+    );
+    const gameSnapshot = prepareYahooGameWeekSnapshot(gameResponse);
+    if (
+      overrideGameId &&
+      gameSnapshot.game.game_id !== Number(overrideGameId)
+    ) {
+      throw new Error("Yahoo game override resolved to another game.");
+    }
+    const gameId = gameSnapshot.game.game_id;
+    const season = gameSnapshot.game.season;
+
+    const { data: storedGame, error: storedGameError } = await supabase
       .from("yahoo_game_keys")
-      .select(
-        "game_id, game_key, season, is_offseason, is_game_over, current_week",
-      )
-      .eq("code", "nhl");
-    gameQuery = overrideGameId
-      ? gameQuery.eq("game_id", Number(overrideGameId)).limit(1)
-      : gameQuery
-          .order("season", { ascending: false })
-          .order("game_id", { ascending: false })
-          .limit(10);
-    const { data: gameRows, error: gameErr } = await gameQuery;
-    if (gameErr) {
-      throw new Error("Yahoo canonical game lookup failed.");
+      .select("game_id, game_key, season")
+      .eq("game_id", gameId)
+      .maybeSingle();
+    if (storedGameError) {
+      throw new Error("Yahoo game metadata lookup failed.");
+    }
+    if (
+      !storedGame ||
+      storedGame.game_key !== gameSnapshot.game.game_key ||
+      Number(storedGame.season) !== season
+    ) {
+      const gameSnapshotId = randomUUID();
+      const { data, error } = await supabase.rpc(
+        "replace_yahoo_game_weeks_snapshot",
+        {
+          p_snapshot_id: gameSnapshotId,
+          p_game: gameSnapshot.game,
+          p_weeks: gameSnapshot.weeks,
+        },
+      );
+      if (error) {
+        throw new Error("Yahoo game metadata persistence failed.");
+      }
+      if (
+        !isYahooGameWeekSnapshotReceipt(
+          data as YahooGameWeekSnapshotReceipt | null,
+          {
+            snapshotId: gameSnapshotId,
+            gameId,
+            gameKey: gameSnapshot.game.game_key,
+            season,
+            sourceCount: gameSnapshot.weeks.length,
+          },
+        )
+      ) {
+        throw new Error("Yahoo game metadata receipt is invalid.");
+      }
     }
 
-    const gameRow = selectCanonicalYahooGame(
-      (gameRows ?? []).map((row) => ({
-        ...row,
-        is_offseason:
-          row.is_offseason == null ? null : Boolean(row.is_offseason),
-        is_game_over:
-          row.is_game_over == null ? null : Boolean(row.is_game_over),
-      })),
-    );
-    if (!gameRow) {
-      throw new Error("Yahoo canonical game is unavailable.");
-    }
-    const gameId = Number(gameRow.game_id);
-    const season = gameRow.season ? Number(gameRow.season) : undefined;
     const [mappedResult, unmatchedResult] = await Promise.all([
       supabase
         .from("yahoo_nhl_player_map")
@@ -123,38 +158,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     };
     console.log(
       `${
-        overrideGameId ? "Using override" : "Detected canonical"
+        overrideGameId ? "Using override" : "Detected live"
       } NHL game_id=${gameId}, season=${season}`,
     );
-
-    const yf = new YahooFantasy(
-      creds.consumer_key,
-      creds.consumer_secret,
-      async ({
-        access_token,
-        refresh_token,
-      }: {
-        access_token: string;
-        refresh_token: string;
-      }) => {
-        console.log("Refreshing tokens...");
-        await persistYahooGlobalTokens(supabase, creds.id, {
-          access_token,
-          refresh_token,
-        });
-        console.log("Tokens refreshed and stored.");
-      },
-    );
-
-    yf.setUserToken(creds.access_token);
-    yf.setRefreshToken(creds.refresh_token);
-
-    let retries = 0;
-    let rateLimitEvents = 0;
     const keySnapshot = await fetchCompleteYahooPlayerKeySnapshot(
       String(gameId),
       (url) =>
-        withYahooRetry(() => (yf as any).api((yf as any).GET, url), {
+        withYahooRetry(() => fetchYahooPublicJson(url), {
           maxAttempts: 3,
           onRetry: ({ rateLimited }) => {
             retries += 1;
@@ -230,7 +240,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       });
     }
 
-    const subresources = ["draft_analysis", "percent_owned"];
     const allRpcPayloads: YahooPlayerAtomicPayload[] = [];
 
     const BATCH_SIZE = 25;
@@ -252,26 +261,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       );
 
       try {
-        let refreshedExpiredToken = false;
-        const players = await withYahooRetry(
-          async () => {
-            try {
-              return await yf.players.fetch(batchKeys, subresources);
-            } catch (fetchErr: any) {
-              const tokenExpired =
-                fetchErr.description?.includes("Invalid cookie") ||
-                fetchErr.message?.includes("Request denied") ||
-                fetchErr.message?.includes("Unexpected token");
-
-              if (!tokenExpired || refreshedExpiredToken) throw fetchErr;
-              refreshedExpiredToken = true;
-              console.warn("Yahoo token expired; refreshing once.");
-              await new Promise<void>((resolve, reject) => {
-                yf.refreshToken((err: any) => (err ? reject(err) : resolve()));
-              });
-              return yf.players.fetch(batchKeys, subresources);
-            }
-          },
+        const response = await withYahooRetry(
+          () =>
+            fetchYahooPublicJson(
+              `players;player_keys=${batchKeys
+                .map(encodeURIComponent)
+                .join(",")};out=draft_analysis,percent_owned`,
+            ),
           {
             maxAttempts: 3,
             onRetry: ({ rateLimited }) => {
@@ -280,13 +276,18 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
             },
           },
         );
+        const players = extractYahooPlayerBatch(response);
 
-        if (players && players.length) {
+        if (players.length) {
+          const requestedKeys = new Set(batchKeys);
           const returnedKeys = new Set(
             players
               .map((playerData: any) => String(playerData?.player_key ?? ""))
               .filter(Boolean),
           );
+          if ([...returnedKeys].some((key) => !requestedKeys.has(key))) {
+            throw new Error("Yahoo player batch returned an unexpected key.");
+          }
           omitted += batchKeys.filter((key) => !returnedKeys.has(key)).length;
           players.forEach((playerData: any) => {
             if (!playerData?.player_key) return;
@@ -457,6 +458,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       success: false,
       status: "failure",
       errorCategory,
+      retries,
+      rateLimitEvents,
       message: "Yahoo player update failed",
     });
   }

--- a/web/pages/api/v1/db/update-yahoo-weeks.ts
+++ b/web/pages/api/v1/db/update-yahoo-weeks.ts
@@ -1,16 +1,12 @@
 // web/pages/api/v1/db/update-yahoo-weeks.ts
 
 import { withCronJobAudit } from "lib/cron/withCronJobAudit";
-import {
-  loadYahooGlobalCredentials,
-  persistYahooGlobalTokens,
-} from "lib/integrations/yahoo/globalCredentials";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createClient } from "@supabase/supabase-js";
-import YahooFantasy from "yahoo-fantasy";
 import { randomUUID } from "node:crypto";
 import adminOnly from "utils/adminOnlyMiddleware";
 import {
+  fetchYahooPublicJson,
   isYahooGameWeekSnapshotReceipt,
   prepareYahooGameWeekSnapshot,
   withYahooRetry,
@@ -34,29 +30,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   let rateLimitEvents = 0;
 
   try {
-    // 1. Get creds & init YahooFantasy
-    const creds = await loadYahooGlobalCredentials(supabase);
-    const yf = new YahooFantasy(
-      creds.consumer_key,
-      creds.consumer_secret,
-      async ({
-        access_token,
-        refresh_token,
-      }: {
-        access_token: string;
-        refresh_token: string;
-      }) => {
-        // Persist refreshed tokens
-        await persistYahooGlobalTokens(supabase, creds.id, {
-          access_token,
-          refresh_token,
-        });
-      },
-    );
-    yf.setUserToken(creds.access_token);
-    yf.setRefreshToken(creds.refresh_token);
-
-    // 2. The scheduled path discovers the current NHL game through Yahoo's
+    // The scheduled path discovers the current NHL game through Yahoo's
     // canonical alias. An explicit key remains a bounded maintenance override.
     const { game_key } = req.query as { game_key?: string };
     const requestedGameKey = game_key || "nhl";
@@ -66,9 +40,12 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         .json({ success: false, message: "Invalid game_key parameter" });
     }
 
-    // 3. Fetch weeks from Yahoo API
+    // Public game metadata does not require a user OAuth token.
     const response = await withYahooRetry<any>(
-      () => yf.game.game_weeks(requestedGameKey),
+      () =>
+        fetchYahooPublicJson(
+          `game/${encodeURIComponent(requestedGameKey)}/game_weeks`,
+        ),
       {
         maxAttempts: 3,
         onRetry: ({ rateLimited }) => {


### PR DESCRIPTION
## What changed

- Move scheduled Yahoo game-week and player reads to the public json_f API.
- Discover the live NHL game through the nhl alias and seed missing game metadata before player ingestion.
- Normalize the 2026–27 response envelopes for weeks, player keys, draft analysis, and ownership.
- Remove the runtime game_id = 465 projection query coupling and filter Yahoo rows by the active NHL season.

## Why

Yahoo opened game 477 for the 2026–27 NHL season. The prior readers depended on the legacy OAuth host/parser and the player route selected stale game 465 from Supabase, causing scheduled ingestion failures.

## Verification

- 45 focused Yahoo/cron tests passed.
- TypeScript passed from a clean worktree based on the current production commit.
- Targeted ESLint passed.
- Live public adapter check resolved game 477 / season 2026, 27 weeks, 1,567 player keys, and a 25-player enriched batch.